### PR TITLE
fhash superbuild fix

### DIFF
--- a/superbuild/dependencies/lightda.cmake
+++ b/superbuild/dependencies/lightda.cmake
@@ -13,6 +13,25 @@ set(lightda_DIR
   "${lightda_INSTALL_DIR}/lib/cmake/lightda" CACHE PATH
   "LightDA config directory")
 
+  set(
+    fhash_GIT_URL
+    "https://github.com/LKedward/fhash.git" CACHE STRING
+    "URL of fhash git repository")
+  
+  set(fhash_INSTALL_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/fhash" CACHE PATH
+    "fhash installation directory")
+  
+  set(fhash_DIR
+    "${fhash_INSTALL_DIR}/lib/cmake/fhash" CACHE PATH
+    "fhash config directory")
+
+    ExternalProject_Add(fhash
+      GIT_REPOSITORY ${fhash_GIT_URL}
+      GIT_TAG master
+      CMAKE_CACHE_ARGS
+        -DCMAKE_INSTALL_PREFIX:PATH=${fhash_INSTALL_DIR})
+
 ExternalProject_Add(lightda
   GIT_REPOSITORY ${lightda_GIT_URL}
   GIT_TAG main
@@ -21,6 +40,7 @@ ExternalProject_Add(lightda
      -DMPI_C_COMPILER:PATH=${MPI_C_COMPILER}
      -Dsystem_mpi_DIR:PATH=${system_mpi_DIR}
      -Dfortran_exceptions_DIR:PATH=${fortran_exceptions_DIR}
+     -Dfhash_DIR:PATH=${fhash_DIR}
     -DPYTHON_EXECUTABLE:PATH=${PYTHON_EXECUTABLE}
     -DCMAKE_INSTALL_PREFIX:PATH=${lightda_INSTALL_DIR}
   DEPENDS system_mpi fortran_exceptions)


### PR DESCRIPTION
This fix adds fhash to superbuild's list of dependencies. One should now be able to run superbuild without having fhash already downloaded.

To test this change, simply run superbuild in the command line.